### PR TITLE
docs: update org homepage readme

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -10,4 +10,15 @@
 | **[Visit our website for documentation and guides 📑](https://sapphirejs.dev)**	| **[View our backlog 🪵](https://github.com/orgs/sapphiredev/projects/1/views/1)**  |
 |-----------------------------------------------------------------------------	| -------------------------------------------------------------------------------	|
 
+<h3>Our Sponsors</h3>
+
+<div>
+  <a href="https://vercel.com/?utm_source=sapphiredev&utm_campaign=oss" rel="noopener noreferrer" target="_blank" aria-label="Sponsor link to Vercel">
+    <img alt="Logo Vercel" src="https://raw.githubusercontent.com/sapphiredev/resource-webhooks/main/public/icons/powered-by-vercel.svg" style="height: 40px;">
+  </a>
+  <a href="https://polypane.app/" rel="noopener noreferrer" target="_blank" aria-label="Sponsor link to Polypane">
+    <img alt="Logo Polypane" src="https://raw.githubusercontent.com/sapphiredev/resource-webhooks/main/public/icons/powered-by-polypane.svg" style="height: 40px;">
+  </a>
+</div>
+
 </div>


### PR DESCRIPTION
Added our sponsors to the main page. Motivation is that I want to sign us up for https://blog.cloudflare.com/cloudflare-new-oss-sponsorships-program/ and they require this so if we're gonna add CF then we may as well also add our current sponsors.