### PR TITLE
docs: remove vercel sponsorship

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -6,16 +6,12 @@
 
 [![Support Server](https://discord.com/api/guilds/737141877803057244/embed.png?style=banner2)](https://sapphirejs.dev/discord)
 
-
-| **[Visit our website for documentation and guides 📑](https://sapphirejs.dev)**	| **[View our backlog 🪵](https://github.com/orgs/sapphiredev/projects/1/views/1)**  |
-|-----------------------------------------------------------------------------	| -------------------------------------------------------------------------------	|
+| **[Visit our website for documentation and guides 📑](https://sapphirejs.dev)** | **[View our backlog 🪵](https://github.com/orgs/sapphiredev/projects/1/views/1)** |
+| ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
 
 <h3>Our Sponsors</h3>
 
 <div>
-  <a href="https://vercel.com/?utm_source=sapphiredev&utm_campaign=oss" rel="noopener noreferrer" target="_blank" aria-label="Sponsor link to Vercel">
-    <img alt="Logo Vercel" src="https://raw.githubusercontent.com/sapphiredev/resource-webhooks/main/public/icons/powered-by-vercel.svg" style="height: 40px;">
-  </a>
   <a href="https://polypane.app/" rel="noopener noreferrer" target="_blank" aria-label="Sponsor link to Polypane">
     <img alt="Logo Polypane" src="https://raw.githubusercontent.com/sapphiredev/resource-webhooks/main/public/icons/powered-by-polypane.svg" style="height: 40px;">
   </a>


### PR DESCRIPTION
Vercel decided to change the pricing plan, dropping us from the 100% off discount, so we do the only rational thing back:


![taking-out-vercel](https://github.com/sapphiredev/.github/assets/4019718/cfa7d685-c500-4ed6-97e0-392dc3733b23)
