### PR TITLE
ci: publish with provenance

### DIFF
--- a/.github/workflows/reusable-continuous-delivery.yml
+++ b/.github/workflows/reusable-continuous-delivery.yml
@@ -83,7 +83,10 @@ jobs:
 
           yarn bump --preid "${TAG}.$(git rev-parse --verify --short HEAD)" --skip-changelog
 
-          yarn npm publish --tag ${TAG} --provenance
+          # Detect whether the current Yarn version is eligible for publishing with provenance (v4.9.0 or later)
+          FLAG=$([ $(node -p "require('semver').gte('$(yarn --version)', '4.9.0')") = true ] && echo '--provenance' || echo '')
+
+          yarn npm publish --tag ${TAG} ${FLAG}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-continuous-delivery.yml
+++ b/.github/workflows/reusable-continuous-delivery.yml
@@ -55,6 +55,8 @@ jobs:
     name: Continuous Delivery
     runs-on: ${{ inputs.operating-system }}
     if: github.repository_owner == 'sapphiredev'
+    permissions:
+      id-token: write
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4
@@ -81,7 +83,7 @@ jobs:
 
           yarn bump --preid "${TAG}.$(git rev-parse --verify --short HEAD)" --skip-changelog
 
-          yarn npm publish --tag ${TAG}
+          yarn npm publish --tag ${TAG} --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-publish.yml
+++ b/.github/workflows/reusable-publish.yml
@@ -95,6 +95,10 @@ jobs:
         run: |
           yarn config set npmAuthToken ${NODE_AUTH_TOKEN}
           yarn config set npmPublishRegistry "https://registry.yarnpkg.com"
-          yarn npm publish --provenance
+
+          # Detect whether the current Yarn version is eligible for publishing with provenance (v4.9.0 or later)
+          FLAG=$([ $(node -p "require('semver').gte('$(yarn --version)', '4.9.0')") = true ] && echo '--provenance' || echo '')
+
+          yarn npm publish ${FLAG}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/.github/workflows/reusable-publish.yml
+++ b/.github/workflows/reusable-publish.yml
@@ -54,6 +54,8 @@ jobs:
     name: Publish ${{ inputs.project-name }}
     runs-on: ${{ inputs.operating-system }}
     if: github.repository_owner == 'sapphiredev'
+    permissions:
+      id-token: write
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4
@@ -93,6 +95,6 @@ jobs:
         run: |
           yarn config set npmAuthToken ${NODE_AUTH_TOKEN}
           yarn config set npmPublishRegistry "https://registry.yarnpkg.com"
-          yarn npm publish
+          yarn npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}


### PR DESCRIPTION
Yarn [v4.9.0](https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.9.0) added support for publishing with provenance.