### PR TITLE
ci(reusable-publish): add contents permission

### DIFF
--- a/.github/workflows/reusable-publish.yml
+++ b/.github/workflows/reusable-publish.yml
@@ -56,6 +56,7 @@ jobs:
     if: github.repository_owner == 'sapphiredev'
     permissions:
       id-token: write
+      contents: write
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4


### PR DESCRIPTION
> Resource not accessible by integration - https://docs.github.com/rest/releases/releases#create-a-release

Hopefully addresses the error shown above by adding the "contents" permission to the workflow. By adding the "id-token" permission, it seems as though all of the default permissions get reset back to none, apart from metadata, which always has read access. 

As such, I would like to apologise for missing this previously!