### PR TITLE
ci: switch to sonarqube-scan-action

### DIFF
--- a/.github/workflows/reusable-sonar.yml
+++ b/.github/workflows/reusable-sonar.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -61,7 +61,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
       - name: SonarCloud Scan
         if: inputs.enable-sonar && github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'sapphiredev')
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
I noticed the following warning on the SonarQube scan action logs, so I thought I'd resolve it for you:

> Warning: This action is deprecated and will be removed in a future release. Please use the sonarqube-scan-action action instead. The sonarqube-scan-action is a drop-in replacement for this action.

<img width="1515" height="197" alt="image" src="https://github.com/user-attachments/assets/ee0d7b00-7601-4307-ad36-e79d6ede5d02" />

Link: https://github.com/SonarSource/sonarqube-scan-action